### PR TITLE
Add support for property names with dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,24 @@ To profit from new activation, add following in your pom.xml:
             </property>
         </activation>
     </profile>            
+
+Since not all property names are valid MVEL identifiers (e.g., an
+identifier cannot contain a dot), an identifier for the properties
+map can be specified with the special `mvel` property name as
+`mvel(<properties-map-identifier>)`.  For example:
+
+    <profile>
+        <id>my-profile</id>
     
+        <activation>
+            <property>
+                <!-- mvel property name is obligatory; identifier p is properties map -->
+                <name>mvel(p)</name>
+                <value>isdef foo.env &amp;&amp; p["foo.env"]=="abc"</value>
+            </property>
+        </activation>
+    </profile>
+
 A few examples (an MVEL cheatsheet)
 -----------------------------------
 
@@ -39,5 +56,9 @@ A few examples (an MVEL cheatsheet)
 * Check if *foo* starts with *abc* or *baz* contains *xyz*
 	
 		isdef foo &amp;&amp; foo.startsWith("abc")) || (isdef baz &amp;&amp; baz.contains("xyz"))
+
+* Check if *foo.env* equals *test* by accessing properties via *p* identifier specified in *name* element as *mvel(p)*
+	
+		isdef foo.env &amp;&amp; p["foo.env"] == "test"
 
 Complete MVEL reference guide is available at http://mvel.codehaus.org/Language+Guide+for+2.0		

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -116,6 +116,134 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>foo equals a1 and mvel parameter list is emtpy</id>
+            <activation>
+                <property>
+                    <name>mvel()</name>
+                    <value>isdef foo &amp;&amp; foo == "a1"</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>foo equals a1 and mvel parameter list is emtpy</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="foo-equals-a1-and-mvel-parameter-list-is-emtpy">
+                                        <echo>foo equals a1 and mvel parameter list is emtpy</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>foo equals a2 and mvel parameter list is whitespace</id>
+            <activation>
+                <property>
+                    <name>mvel(   )</name>
+                    <value>isdef foo &amp;&amp; foo == "a2"</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>foo equals a2 and mvel parameter list is whitespace</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="foo-equals-a2-and-mvel-parameter-list-is-whitespace">
+                                        <echo>foo equals a2 and mvel parameter list is whitespace</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>foo.env equals a1 and properties identifier is p</id>
+            <activation>
+                <property>
+                    <name>mvel(p)</name>
+                    <value>isdef foo.env &amp;&amp; p["foo.env"] == "a1"</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>foo.env equals a1 and properties identifier is p</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="foo.env-equals-a1-and-properties-identifier-is-p">
+                                        <echo>foo.env equals a1 and properties identifier is p</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>foo.env equals a2 and properties identifier is p with whitespace</id>
+            <activation>
+                <property>
+                    <name>mvel(   p   )</name>
+                    <value>isdef foo.env &amp;&amp; p["foo.env"] == "a2"</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>foo.env equals a2 and properties identifier is p with whitespace</id>
+                                <phase>validate</phase>
+                                <configuration>
+                                    <target name="foo.env-equals-a2-and-properties-identifier-is-p-with-whitespace">
+                                        <echo>foo.env equals a2 and properties identifier is p with whitespace</echo>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Add support for property names that are not valid MVEL identifiers (e.g., a property name with a dot in it such as `foo.env`) by adding support for an `mvel(<properties-map-identifier>)` syntax for the special `mvel` property name allowing a properties map identifier to be specified.  The previous `mvel` syntax (i.e., the four-character literal) works as before.

For example, if the special property name were

```
mvel(p)
```

the value of the property `foo.env` could be accessed in the MVEL expression with

```
p["foo.env"]
```

Fixes issue #4.