### PR TITLE
Fix compile warnings about using platform encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,9 @@
     <artifactId>el-profile-activator-extension</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>El Profile Activator Maven Extension</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Set the `project.build.sourceEncoding` property to `UTF-8` to eliminate the following `compile` phase warnings:

```
$ mvn compile
[INFO] Scanning for projects...
[INFO]
[INFO] -------< com.redhat.jboss.maven:el-profile-activator-extension >--------
[INFO] Building El Profile Activator Maven Extension 1.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ el-profile-activator-extension ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /tmp/el-profile-activator-extension/src/main/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ el-profile-activator-extension ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 1 source file to /tmp/el-profile-activator-extension/target/classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.201 s
[INFO] Finished at: 2018-10-24T15:12:47-05:00
[INFO] ------------------------------------------------------------------------
```